### PR TITLE
Adapt to Ubuntu 20.04 and Python 3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && apt-get install -y apt-utils
 RUN apt-get install -y --no-install-recommends \
-    python-django \
+    python3-django \
     apache2 \
+    apache2-dev \
     curl \
     make \
     gcc \
@@ -10,11 +12,11 @@ RUN apt-get install -y --no-install-recommends \
     libcairo2-dev \
     libnetpbm10-dev \
     netpbm \
-    libpng12-dev \
+    libpng-dev \
     libjpeg-dev \
-    python-numpy \
-    python-pyfits \
-    python-dev \
+    python3-numpy \
+    python3-dev \
+    python3-setuptools \
     libbz2-dev \
     swig \
     pkg-config \
@@ -22,24 +24,20 @@ RUN apt-get install -y --no-install-recommends \
     libcfitsio-dev \
     ssl-cert \
     ca-certificates \
-    libapache2-mod-wsgi \
-    python-psycopg2 \
-    python-pip \
-    python-pil \
+    python3-psycopg2 \
+    python3-pip \
+    python3-pil \
     sqlite3 \
-    python-matplotlib \
-    python-tk \
+    python3-matplotlib \
+    python3-tk \
     file \
     apt-utils \
     libgsl-dev \
     unhide \
     wget
 
-# Remove APT files
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
 # Python related stuff
-RUN pip install --upgrade\
+RUN pip3 install --upgrade\
     pip
 RUN for x in \
     setuptools \
@@ -48,15 +46,18 @@ RUN for x in \
     simplejson \
     social-auth-core \
     social-auth-app-django \
-    ; do pip install $x; done
+    mod_wsgi \
+    ; do pip3 install $x; done
+
+# TODO: install pyfits as dependency
 
 RUN mkdir -p /src \
     && cd /src \
     && git clone http://github.com/dstndstn/astrometry.net.git astrometry \
     && cd astrometry \
-    && make \
-    && make py \
-    && make extra \
+    && make -j \
+    && make py -j \
+    && make extra -j \
     && make install INSTALL_DIR=/usr/local
 
 RUN cd /etc/apache2/mods-enabled \
@@ -79,21 +80,37 @@ COPY docker.cfg      /src/astrometry/net/
 COPY solvescript.sh  /src/astrometry/net/
 COPY apache2.conf    /etc/apache2/
 
-#WARNING : you need to run this in you shell before nuilding image
+#WARNING : you need to run this in you shell before building image
 #RUN cd /INDEXES/ \
 #  && for i in 4100 4200; do \
 #    wget -r -l1 --no-parent -nc -nd -A ".fits" http://data.astrometry.net/$i/;\
 #    done
 
 RUN cd /src/astrometry/net \
-    && python manage.py makemigrations \
-    && python manage.py migrate \
-    && python manage.py loaddata fixtures/* \
+    && cp -ar appsecrets-example appsecrets \
+    && python3 manage.py makemigrations \
+    && python3 manage.py migrate \
+    && python3 manage.py loaddata fixtures/* \
     && chmod 755 solvescript.sh
 
+RUN mkdir /data2
+RUN mkdir /data2/nova
+RUN chown -R nova:nova /data2
+# Uncomment to download the data file for Skyplot
+# https://github.com/dstndstn/nova-docker/issues/1#issuecomment-359441985
+# RUN wget http://data.astrometry.net/tycho2.kd -o /data2/nova/tycho2.kd
+
 RUN chown -R nova.nova /src/astrometry
+RUN mkdir /data
+RUN mkdir /data/nova
+RUN chown -R nova:nova /data/nova
+RUN ln -s /bin/python3 /bin/python
+
+# Necessary to add the site-packages into system path for Apache2 to properly load django.
+# Should be safe to hard code the python version given 20.04 is already pretty outdated.
+RUN echo 'export PATH="$PATH:/usr/local/lib/python3.8/dist-packages"' >> ~/.bashrc
 
 EXPOSE 80
 CMD ["/bin/bash", "./start.sh"]
-#Build with docker build -t astrometryserver .
-#Launch with docker run -d -p 80:80 --mount type=bind,source=$PWD/INDEXES,target=/INDEXES astrometryserver
+# Build with docker build -t astrometryserver .
+# Launch with docker run -d -p 80:80 --mount type=bind,source=$PWD/INDEXES,target=/INDEXES astrometryserver

--- a/README.md
+++ b/README.md
@@ -14,15 +14,18 @@ cd /INDEXES/ \
     done
 ```
 This process may take some time, so it's advisable to start early and continue reading the `README` file and the `Dockerfile` in the meantime.
+
 2. Next, build the Docker image using the example command line provided. Modify according to your needs.
 ```
 sudo docker build -t nova-docker .
 ```
+
 3. Once the image is built, launch it using the example command line.
 ```
 sudo docker run -d -p 8000:80 --mount type=bind,source=$PWD/INDEXES,target=/INDEX nova-docker
 ```
 This command will launch a docker instance, start the backend and frontend of the Nova system, listen on port 80. And then it will map the Docker instance's 80 port to the host's 8000 port. If you are deploying in a production environment, you may want to put it as 80 instead of 8000 as well, or use a reverse proxy.
+
 4. Lastly, make necessary changes in the code. To do this, execute the provided command line to enter the Docker image.
 ```
 sudo docker exec -it 3581ccc20fa9 /bin/bash

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # nova-docker
-playing with creating a Docker container for the nova.astrometry.net web site
+
+This repository offers a reference implementation for deploying a local instance of Astrometry.net Nova frontend and backend.
+While all the necessary information and steps are detailed in the `Dockerfile`, for a quick start, we've provided a high-level overview in the following instructions.
+However, it's highly recommended to read the `Dockerfile` to be technically and mentally prepared for any potential issues before executing anything.
+It's also beneficial to read [this GitHub issue](https://github.com/dstndstn/nova-docker/issues/1) to troubleshoot any errors during the deployment process.
+
+1. Start by downloading the index file. Execute the command mentioned in the `Dockerfile`, which is also provided here for convenience. 
+```
+mkdir -p INDEXES
+cd /INDEXES/ \
+  && for i in 4100 4200; do \
+    wget -r -l1 --no-parent -nc -nd -A ".fits" http://data.astrometry.net/$i/;\
+    done
+```
+This process may take some time, so it's advisable to start early and continue reading the `README` file and the `Dockerfile` in the meantime.
+2. Next, build the Docker image using the example command line provided. Modify according to your needs.
+```
+sudo docker build -t nova-docker .
+```
+3. Once the image is built, launch it using the example command line.
+```
+sudo docker run -d -p 8000:80 --mount type=bind,source=$PWD/INDEXES,target=/INDEX nova-docker
+```
+This command will launch a docker instance, start the backend and frontend of the Nova system, listen on port 80. And then it will map the Docker instance's 80 port to the host's 8000 port. If you are deploying in a production environment, you may want to put it as 80 instead of 8000 as well, or use a reverse proxy.
+4. Lastly, make necessary changes in the code. To do this, execute the provided command line to enter the Docker image.
+```
+sudo docker exec -it 3581ccc20fa9 /bin/bash
+```
+The `3581ccc20fa9` is a hash you can find either from `sudo docker ps` or the output from the last step.
+You may need to modify `/src/astrometry/net/appsecrets`, which is a simple copy of the `appsecrets-example`, to change the passwords/secrets of the database and other components. Additionally, you might need to change the `settings.py` file to include your hostname in the settings, preventing an error like 'hostname is not in the allowed host'. Here's an example, assuming you're deploying this instance to a website named example.com.
+```
+ALLOWED_HOSTS = ['example.com']
+```
+5. Then the Nova website can be accessed through http://example.com/ or http://localhost if you are deploying on localhost.

--- a/apache2.conf
+++ b/apache2.conf
@@ -88,6 +88,9 @@ Include conf-enabled/[^.#]*
 #PassEnv TMPDIR
 #PassEnv TMP
 
+# In Python3 + wsgi_mod, one needs to add the specific path to the LoadModule
+# https://stackoverflow.com/questions/70698267/apache-wsgi-mod-fails-to-run-on-python-3-10
+LoadModule wsgi_module "/usr/local/lib/python3.8/dist-packages/mod_wsgi/server/mod_wsgi-py38.cpython-38-x86_64-linux-gnu.so"
 WSGIScriptAlias / /src/astrometry/net/wsgi.py
 
 <Directory /src/astrometry/net>


### PR DESCRIPTION
Deploying a complex system like Astrometry.net Nova is never an easy task. This is why this project is incredibly useful, as it allows users to deploy a local instance with just one or two command lines. However, several years have passed since the last update of this project, resulting in a gap in updates across different operating systems and packages. The most significant of these is the deprecation of Python 2. In this pull request, we aim to address this by upgrading the Python version from 2 to 3. This involves several specific changes:

1. The Ubuntu version has been upgraded to 20.04, which supports a decent version of Python.
2. All dependencies, including `setuptools`, `pip`, Python libraries, and Python itself, have been updated from Python 2 to Python 3.
3. The interactive mode of `apt-get` has been deactivated to ensure that the docker image build process doesn't get stuck at a point where a specific package requires user interaction via the keyboard. 
4. We've incorporated directory preparation with the correct owner and privilege setup to prevent the `start.sh` from crashing due to an inability to write the log file. 
5. Significant modifications have been implemented to make the Apache WSGI compatible with Python 3. 
6. Currently, `pyfits `is deprecated and I've simply disabled it without encountering any disastrous outcomes. However, advice on whether this is a safe action would be greatly appreciated.

We also added a detailed `README.md` file to make the users’ life easier, with some minor optimizations such as automatic copying the `appsecrets-example` to ensure a successful docker image build without human intervention.